### PR TITLE
Configurable suffixes

### DIFF
--- a/lib/switch-header-source.coffee
+++ b/lib/switch-header-source.coffee
@@ -6,6 +6,7 @@ module.exports =
     headerFileRegex:
       type: 'string'
       default: '\\.h|\\.hpp|\\.hh|\\.hxx'
+      title: 'Header file regular expression'
       description: """Regular expression used to identify "header" file
                       suffixes (matched at the end of the file name, remember
                       to escape \'.\')"""
@@ -13,6 +14,7 @@ module.exports =
     definitionFileRegex:
       type: 'string'
       default: '\\.c|\\.cpp|\\.cc|\\.cxx|\\.m|\\.mm'
+      title: 'Definition file regular expression'
       description: """Regular expression used to identify "definition" file
                       suffixes (matched at the end of the file name, remember
                       to escape \'.\')"""
@@ -25,6 +27,22 @@ module.exports =
 
   activate: ->
     atom.commands.add 'atom-workspace', 'switch-header-source:switch', => @switch()
+    atom.config.onDidChange 'switch-header-source.headerFileRegex', (value) => @createRegExp()
+    atom.config.onDidChange 'switch-header-source.definitionFileRegex', (value) => @createRegExp()
+    @createRegExp()
+
+  createRegExp: ->
+    try
+      @headerRegex = new RegExp(
+        '(.*)(' + atom.config.get('switch-header-source.headerFileRegex') + ')$'
+      )
+      @definitionRegex = new RegExp(
+        '(.*)(' + atom.config.get('switch-header-source.definitionFileRegex') + ')$'
+      )
+    catch error
+      # TODO: Inform the user of an invalid regular expression?
+      @headerRegex = /(.*)(\.h|\.hpp|\.hh|\.hxx)$/
+      @definitionRegex = /(.*)(\.c|\.cpp|\.cc|\.cxx|\.m|\.mm)$/
 
   switch: ->
     # Check if the active item is a text editor
@@ -32,14 +50,6 @@ module.exports =
     return unless editor?
 
     file   = editor.getPath()
-
-    @headerRegex = new RegExp(
-      '(.*)(' + atom.config.get('switch-header-source.headerFileRegex') + ')$',
-    )
-    @definitionRegex = new RegExp(
-      '(.*)(' + atom.config.get('switch-header-source.definitionFileRegex') + ')$',
-    )
-
     dir  = path.dirname  file
     name = path.basename file
 

--- a/lib/switch-header-source.coffee
+++ b/lib/switch-header-source.coffee
@@ -33,37 +33,33 @@ module.exports =
 
     file   = editor.getPath()
 
-    headerRegex = new RegExp(
+    @headerRegex = new RegExp(
       '(.*)(' + atom.config.get('switch-header-source.headerFileRegex') + ')$',
-      'i'
     )
-    definitionRegex = new RegExp(
+    @definitionRegex = new RegExp(
       '(.*)(' + atom.config.get('switch-header-source.definitionFileRegex') + ')$',
-      'i'
     )
 
     dir  = path.dirname  file
     name = path.basename file
 
-    if headerRegex.test name
-      @name = name.match(headerRegex)
-      if not @findInDir dir, definitionRegex
-        @find dir, 'include', 'src', definitionRegex
+    if @headerRegex.test name
+      @name = name.match(@headerRegex)
+      if not @findInDir dir, @definitionRegex
+        @find dir, 'include', 'src', @definitionRegex
 
-    else if definitionRegex.test name
-      @name = name.match(definitionRegex)
-      if not @findInDir dir, headerRegex
-        @find dir, 'src', 'include', headerRegex
+    else if @definitionRegex.test name
+      @name = name.match(@definitionRegex)
+      if not @findInDir dir, @headerRegex
+        @find dir, 'src', 'include', @headerRegex
 
   # find corresponding file in 'dir' directory
   findInDir: (dir, expression) ->
     fullName = path.join dir, @name[1]
     foundFile = null
     for fileName in fs.listSync(dir)
-      if fs.isFileSync(fileName)
-        match = fileName.match(expression)
-        foundFile = fileName if match and match[1] == fullName
-        break if foundFile
+      foundFile = fileName if fileName.match(expression) and fileName.match(expression)[1] == fullName
+      break if foundFile
     atom.workspace.open foundFile, { searchAllPanes: !atom.config.get('switch-header-source.samePane') } if foundFile
     foundFile
 

--- a/lib/switch-header-source.coffee
+++ b/lib/switch-header-source.coffee
@@ -1,3 +1,4 @@
+$    = require 'jquery'
 fs   = require 'fs-plus'
 path = require 'path'
 
@@ -32,14 +33,25 @@ module.exports =
     @createRegExp()
 
   createRegExp: ->
+    console.log "createRegExp"
     try
+      $('.header-regex-error')?.remove()
+      headerRegexError = $('<span class="header-regex-error">Error in regular expression!</span>')
+      $('#switch-header-source\\.headerFileRegex').after(headerRegexError)
       @headerRegex = new RegExp(
         '(.*)(' + atom.config.get('switch-header-source.headerFileRegex') + ')$'
       )
+      headerRegexError.remove()
+
+      $('.definition-regex-error')?.remove()
+      defintionRegexError = $('<span class="header-regex-error">Error in regular expression!</span>')
+      $('#switch-header-source\\.definitionFileRegex').after(defintionRegexError)
       @definitionRegex = new RegExp(
         '(.*)(' + atom.config.get('switch-header-source.definitionFileRegex') + ')$'
       )
+      defintionRegexError.remove()
     catch error
+      console.log "catch"
       # TODO: Inform the user of an invalid regular expression?
       @headerRegex = /(.*)(\.h|\.hpp|\.hh|\.hxx)$/
       @definitionRegex = /(.*)(\.c|\.cpp|\.cc|\.cxx|\.m|\.mm)$/

--- a/lib/switch-header-source.coffee
+++ b/lib/switch-header-source.coffee
@@ -46,43 +46,29 @@ module.exports =
     name = path.basename file
 
     if headerRegex.test name
-      #console.log "header"
-      #console.log name
-      #console.log name.match(headerRegex)
       @name = name.match(headerRegex)
       if not @findInDir dir, definitionRegex
         @find dir, 'include', 'src', definitionRegex
 
     else if definitionRegex.test name
-      #console.log "definition"
-      #console.log name
-      #console.log name.match(definitionRegex)
       @name = name.match(definitionRegex)
       if not @findInDir dir, headerRegex
         @find dir, 'src', 'include', headerRegex
 
   # find corresponding file in 'dir' directory
   findInDir: (dir, expression) ->
-    #console.log @name
-    #console.log @name[1]
     fullName = path.join dir, @name[1]
-    #console.log fullName
     foundFile = null
     for fileName in fs.listSync(dir)
-      #console.log "::: ", fileName
       if fs.isFileSync(fileName)
-        #console.log "  : is a file"
         match = fileName.match(expression)
         foundFile = fileName if match and match[1] == fullName
-        #console.log "  : FOUND MATCH" if foundFile
-        #console.log "  :", foundFile if foundFile
         break if foundFile
     atom.workspace.open foundFile, { searchAllPanes: !atom.config.get('switch-header-source.samePane') } if foundFile
     foundFile
 
   # find corresponding file in alternate subtree
   find: (currentDir, upperBound, searchFrom, expression) ->
-    #console.log "SUBTREE SEARCH"
     nodes = currentDir.split path.sep
     index = nodes.lastIndexOf upperBound
     return if index == -1

--- a/lib/switch-header-source.coffee
+++ b/lib/switch-header-source.coffee
@@ -6,14 +6,14 @@ module.exports =
     headerFileRegex:
       type: 'string'
       default: '\\.h|\\.hpp|\\.hh|\\.hxx'
-      description: """Regular expression to use to identify "header" file
+      description: """Regular expression used to identify "header" file
                       suffixes (matched at the end of the file name, remember
                       to escape \'.\')"""
       order: 1
     definitionFileRegex:
       type: 'string'
       default: '\\.c|\\.cpp|\\.cc|\\.cxx|\\.m|\\.mm'
-      description: """Regular expression to use to identify "definition" file
+      description: """Regular expression used to identify "definition" file
                       suffixes (matched at the end of the file name, remember
                       to escape \'.\')"""
       order: 2

--- a/lib/switch-header-source.coffee
+++ b/lib/switch-header-source.coffee
@@ -3,10 +3,25 @@ path = require 'path'
 
 module.exports =
   config:
+    headerFileRegex:
+      type: 'string'
+      default: '\\.h|\\.hpp|\\.hh|\\.hxx'
+      description: """Regular expression to use to identify "header" file
+                      suffixes (matched at the end of the file name, remember
+                      to escape \'.\')"""
+      order: 1
+    definitionFileRegex:
+      type: 'string'
+      default: '\\.c|\\.cpp|\\.cc|\\.cxx|\\.m|\\.mm'
+      description: """Regular expression to use to identify "definition" file
+                      suffixes (matched at the end of the file name, remember
+                      to escape \'.\')"""
+      order: 2
     samePane:
       type: 'boolean'
       default: false
       description: 'Keep header and source files in the same pane.'
+      order: 3
 
   activate: ->
     atom.commands.add 'atom-workspace', 'switch-header-source:switch', => @switch()
@@ -18,8 +33,14 @@ module.exports =
 
     file   = editor.getPath()
 
-    headerRegex = /(.*)(\.h|\.hpp|\.hh|\.hxx|_def\.lua)$/i
-    definitionRegex = /(.*)(\.c|\.cpp|\.cc|\.cxx|\.m|\.mm|\.lua)$/i
+    headerRegex = new RegExp(
+      '(.*)(' + atom.config.get('switch-header-source.headerFileRegex') + ')$',
+      'i'
+    )
+    definitionRegex = new RegExp(
+      '(.*)(' + atom.config.get('switch-header-source.definitionFileRegex') + ')$',
+      'i'
+    )
 
     dir  = path.dirname  file
     name = path.basename file

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "atom": ">=0.190.0"
   },
   "dependencies": {
-    "fs-plus": "^2.0.4"
+    "fs-plus": "^2.0.4",
+    "jquery": "^2"
   },
   "keywords": [
     "C++",

--- a/styles/switch-header-source.less
+++ b/styles/switch-header-source.less
@@ -1,0 +1,3 @@
+.header-regex-error, .definition-regex-error {
+  color: red;
+}


### PR DESCRIPTION
This pull request allows you to configure the header/source file name suffixes.

With configurable suffixes, you can switch between any two related files, e.g. `.css` and `.sass`, etc.

This would close https://github.com/dschwen/switch-header-source/issues/5.

**Example of a use case:**
We use a custom class system in Lua, where the "header" file is `ClassName.lua` and the "definition" file is `ClassName_def.lua`.

Note that the extension doesn't actually change, so the old way of just matching the extension wouldn't work here (the extension needs to stay the same, because some tools rely on it to recognize it as a Lua file).

In the above case, the regular expressions would be configured to `\.h|\.hpp|\.hh|\.hxx|_def\.lua` and `\.c|\.cpp|\.cc|\.cxx|\.m|\.mm|\.lua`.

**NOTE:**
This works for me, but I haven't tested it too much yet. Subtree searching (`find()` instead of `findInDir()`) might be broken, but I'm not entirely sure.

Also, this is the first time I've ever written CoffeeScript, so the code could be full of mistakes.