### PR TITLE
Fix q.drain error 

### DIFF
--- a/lib/switch-header-source.coffee
+++ b/lib/switch-header-source.coffee
@@ -107,4 +107,4 @@ module.exports =
     if not @findInDir perfectDir, name, expressionA, expressionB
       dir = nodes[0..index].join path.sep
       if not @findInDir dir, name, expressionA, expressionB
-        fs.traverseTree dir, (->), ((d) => not @findInDir d, name, expressionA, expressionB)
+        fs.traverseTree dir, (->), ((d) => not @findInDir d, name, expressionA, expressionB), (->)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "atom": ">=0.190.0"
   },
   "dependencies": {
-    "fs-plus": "^2.0.4",
+    "fs-plus": "^3.0.0",
     "jquery": "^2"
   },
   "keywords": [


### PR DESCRIPTION
`traverseTree` needs a fourth argument (this is _not_ optional anymore)

Closes #13