### PR TITLE
Rewrite plugin to use index based switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # switch-header-source package
 
 Quick switching between C, C++, Objective-C, and Objective-C++ header and source
-files.
+files...
+
+...Actually between any arbitrarily defined groups of files (as long as you can match
+their filenames with a regular expression)!
+
+For example:
+
+* Switch between `.C`, `.h`, and `.md` files (for implementation, headers, and
+  class documentation files)
+* Switch between `.js`, `.html`, and `.css` files
+* Your imagination is the limit.. if not, [file an issue](https://github.com/dschwen/switch-header-source/issues)!
 
 ![switching-in-action](http://i.imgur.com/TPJtS1n.gif)
 
 ## Mac
-Use ```Ctrl-Option-s``` to switch from a ```.h``` to the corresponding ```.C``` file.
+Use ```Ctrl-Option-s``` to cycle though groups of matching files.
 
 ## Linux, Windows
 Use ```Alt-o``` to alternate between a header and its corresponding source file.

--- a/lib/switch-header-source.coffee
+++ b/lib/switch-header-source.coffee
@@ -88,12 +88,12 @@ module.exports =
     try
       $('.file-regex-error')?.remove()
       fileRegexError = $('<span class="file-regex-error">Error in regular expression!</span>')
-      $('#switch-header-source\\.headerFileRegex')?.after(fileRegexError)
+      $('#switch-header-source\\.fileRegex')?.after(fileRegexError)
       @fileRegex = new RegExp(atom.config.get('switch-header-source.fileRegex'))
       fileRegexError.remove()
 
     catch error
-      @fileRegex = /(.*)(\.h|\.hpp|\.hh|\.hxx|\.[cC]|\.cpp|\.cc|\.cxx|\.m|\.mm)$/
+      @fileRegex = /(.*)(\.h(pp|xx)|\.(hh|cc|mm)|\.[mhcC]|\.c(pp|xx))$/
 
   switch: ->
     # Check if the active item is a text editor

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "main": "./lib/switch-header-source",
   "version": "0.22.0",
   "description": "Quick switching between C/C++/Objective-C header and source files",
-  "activationCommands": {
-    "atom-workspace": [
-      "switch-header-source:switch"
-    ]
+  "consumedServices": {
+    "busy-signal": {
+      "versions": {
+        "1.0.0": "consumeSignal"
+      }
+    }
   },
   "repository": "https://github.com/dschwen/switch-header-source",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "fs-plus": "^3.0.0",
     "jquery": "^2"
   },
+  "packageDependencies": {
+    "fuzzy-finder": "1.6.1"
+  },
   "keywords": [
     "C++",
     "C",

--- a/styles/switch-header-source.less
+++ b/styles/switch-header-source.less
@@ -1,3 +1,3 @@
-.header-regex-error, .definition-regex-error {
+.file-regex-error {
   color: red;
 }


### PR DESCRIPTION
The plugin now uses a background task to index all files matched by a given regular expression (index is incrementally updated as files are created, deleted, or renamed). This allows for switch cycles of arbitrary size...

Closes #10 

...and now removes all assumptions on the directory structure

Closes #11 